### PR TITLE
CTFBOT-34 Напоминания о приближающихся дедлайнах и мероприятиях.

### DIFF
--- a/bot/database/competition_dao.py
+++ b/bot/database/competition_dao.py
@@ -4,7 +4,7 @@ from database.models import Competition
 
 
 class CompetitionDao:
-    """Data access object for Task"""
+    """Data access object for Competition"""
 
     def __init__(self, session):
         self.session = session
@@ -29,3 +29,14 @@ class CompetitionDao:
         self.session.commit()
         self.session.refresh(new_competition)
         return new_competition
+
+    def get_events_between(self, start_time: datetime, end_time: datetime):
+        """Получить события в заданном временном диапазоне."""
+        return (
+            self.session.query(Competition)
+            .filter(
+                Competition.date >= start_time,
+                Competition.date < end_time
+            )
+            .all()
+        )

--- a/bot/main.py
+++ b/bot/main.py
@@ -67,7 +67,6 @@ dp.message.middleware(AuthMiddleware())
 
 
 async def main():
-
     scheduler = AsyncIOScheduler()
     # Добавляем периодическую задачу восстановления жизней
     # Выполняется каждое 10-е число месяца в 00:00 по МСК (UTC+3)
@@ -83,8 +82,6 @@ async def main():
         name="Восстановление жизней студентов",
         replace_existing=True,
     )
-
-    
     scheduler.add_job(
         send_event_notifications,
         args=[bot],
@@ -102,8 +99,8 @@ async def main():
     await bot.set_my_commands(commands)
     # Запускаем задачу синхронизации задач
     asyncio.create_task(sync_education_tasks(bot))  # Фоновая задача
-
     await dp.start_polling(bot)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/bot/main.py
+++ b/bot/main.py
@@ -22,6 +22,7 @@ from handlers import (
 from settings import config
 from middlewares import AuthMiddleware
 from tasks import sync_education_tasks
+from tasks import send_event_notifications
 
 # Включаем логирование, чтобы не пропустить важные сообщения
 logging.basicConfig(level=logging.INFO)
@@ -83,6 +84,19 @@ async def main():
         replace_existing=True,
     )
 
+    
+    scheduler.add_job(
+        send_event_notifications,
+        args=[bot],
+        trigger=CronTrigger(
+            hour=6,
+            minute=0,
+            timezone=timezone("Europe/Moscow"),
+        ),
+        id="send_event_notifications",
+        name="Отправка уведомлений о событиях",
+        replace_existing=True,
+    )
     # Запускаем планировщик
     scheduler.start()
     await bot.set_my_commands(commands)

--- a/bot/tasks.py
+++ b/bot/tasks.py
@@ -77,6 +77,7 @@ async def restore_student_lives():
     except Exception as e:
         logger.error(f"Ошибка при восстановлении жизней: {e}")
 
+
 async def send_event_notifications(bot: Bot):
     """Отправка уведомлений о событиях за 1 день и в день мероприятия."""
     try:
@@ -86,24 +87,21 @@ async def send_event_notifications(bot: Bot):
         today_end = today_start + timedelta(days=1)
         tomorrow_start = today_start + timedelta(days=1)
         tomorrow_end = today_start + timedelta(days=2)
-        
         with get_db() as session:
             dao = CompetitionDao(session)
             today_events = dao.get_events_between(today_start, today_end)
             tomorrow_events = dao.get_events_between(tomorrow_start, tomorrow_end)
-            
             for event in today_events:
                 logger.info(f"Уведомление о событии сегодня: {event.name}")
                 # Здесь можно добавить отправку через bot, например:
                 # await bot.send_message(chat_id, f"Сегодня: {event.name} в {event.date}")
-            
             for event in tomorrow_events:
                 logger.info(f"Уведомление о событии завтра: {event.name}")
                 # Здесь можно добавить отправку через bot, например:
                 # await bot.send_message(chat_id, f"Завтра: {event.name} в {event.date}")
-                
     except Exception as e:
         logger.error(f"Ошибка при отправке уведомлений: {e}")
+
 
 if __name__ == "__main__":
     asyncio.run(sync_education_tasks())

--- a/bot/tasks.py
+++ b/bot/tasks.py
@@ -1,11 +1,14 @@
 import asyncio
+from datetime import datetime, timedelta
 from aiogram import Bot
 from logging import getLogger
+from pytz import timezone
 
 from utils.notifications import Notifications
 from database.db import get_db
 from database.user_dao import UserDAO
 
+from database.competition_dao import CompetitionDao
 from utils.root_me import get_solved_tasks_of_student
 
 
@@ -74,6 +77,33 @@ async def restore_student_lives():
     except Exception as e:
         logger.error(f"Ошибка при восстановлении жизней: {e}")
 
+async def send_event_notifications(bot: Bot):
+    """Отправка уведомлений о событиях за 1 день и в день мероприятия."""
+    try:
+        moscow_tz = timezone('Europe/Moscow')
+        now = datetime.now(moscow_tz)
+        today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        today_end = today_start + timedelta(days=1)
+        tomorrow_start = today_start + timedelta(days=1)
+        tomorrow_end = today_start + timedelta(days=2)
+        
+        with get_db() as session:
+            dao = CompetitionDao(session)
+            today_events = dao.get_events_between(today_start, today_end)
+            tomorrow_events = dao.get_events_between(tomorrow_start, tomorrow_end)
+            
+            for event in today_events:
+                logger.info(f"Уведомление о событии сегодня: {event.name}")
+                # Здесь можно добавить отправку через bot, например:
+                # await bot.send_message(chat_id, f"Сегодня: {event.name} в {event.date}")
+            
+            for event in tomorrow_events:
+                logger.info(f"Уведомление о событии завтра: {event.name}")
+                # Здесь можно добавить отправку через bot, например:
+                # await bot.send_message(chat_id, f"Завтра: {event.name} в {event.date}")
+                
+    except Exception as e:
+        logger.error(f"Ошибка при отправке уведомлений: {e}")
 
 if __name__ == "__main__":
     asyncio.run(sync_education_tasks())


### PR DESCRIPTION
В tasks.py добавил функцию send_event_notifications, которая проверяет события из Competition на сегодня и завтра для отправки уведомлений. В main.py добавил запуск этой функции через APScheduler на 6 утра по Москве. В competition_dao.py добавил метод get_events_between для выборки событий по временному диапазону. 

Пока на работу не проверял в своем боте, но установил мероприятие на 01.06.2025 и оно по идее должно предупредить сегодня в 6 часов утра, но так как сервер локальный на ноуте и я вырублю ноут я не получу уведомление, поэтому не получится проверить.

И еще момент, я бы поменял сообщение с форматом даты при создании мероприятия.
Поменял бы с такого как на скрине (д.м.г), на такой: (дд.мм.гггг), а то чуть не понятно как вводить. Ну это мелочь, которую заметил.
![изображение](https://github.com/user-attachments/assets/f504bdfa-6cd2-4c26-bd48-96fe1c859529)
