### PR TITLE
Fix heal command to update persistent user instance

### DIFF
--- a/bot/database/user_dao.py
+++ b/bot/database/user_dao.py
@@ -65,12 +65,14 @@ class UserDAO:
             user.tasks = [task for task in user.tasks if not task.completed]
         return users
 
-    def heal(self, user: User) -> None:
+    def heal(self, user: User) -> User:
         """Обменять 10 опыта на 3 жизни."""
-        user.lives += 3
-        user.points -= 10
+        persistent_user = self.session.merge(user)
+        persistent_user.lives += 3
+        persistent_user.points -= 10
         self.session.commit()
-        self.session.refresh(user)
+        self.session.refresh(persistent_user)
+        return persistent_user
 
     def get_teachers(self) -> List[User]:
         """Получить всех учителей (старшекурсников) по tg_id."""

--- a/bot/handlers/heal.py
+++ b/bot/handlers/heal.py
@@ -22,7 +22,7 @@ async def heal_handler(message: Message, user: User):
         )
     with get_db() as db:
         user_dao = UserDAO(db)
-        user_dao.heal(user)
+        updated_user = user_dao.heal(user)
         await message.answer(
-            f"Увеличил твою HP на одну 🩹\n Теперь у тебя {user.lives}❤️."
+            f"Увеличил твою HP на одну 🩹\n Теперь у тебя {updated_user.lives}❤️."
         )


### PR DESCRIPTION
## Summary
- ensure UserDAO.heal merges the user into the active session before applying changes
- update the heal handler to use the refreshed user data after healing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69063fc37c088328a9d5080a2461ec4a